### PR TITLE
Move super higher in setupController

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -51,7 +51,7 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
         const redux = this.get('redux');
         const params = this.getCurrentParams(controller);
         const props = stateToComputed(redux.getState(), params);
-
+        this._super(...arguments);
         // Add new props to the controller
         Object.keys(props).forEach(name => {
           defineProperty(controller, name, computed(() =>
@@ -78,8 +78,6 @@ export default (stateToComputed=() => ({}), dispatchToActions=() => ({})) => {
         controller.actions = Object.assign({},
           controller.actions, dispatchToActions(redux.dispatch.bind(redux), params)
         );
-
-        this._super(...arguments);
       },
 
       /**

--- a/tests/acceptance/connected-route-test.js
+++ b/tests/acceptance/connected-route-test.js
@@ -14,6 +14,7 @@ test('computed properties', assert => {
     assert.equal(currentURL(), '/item/123?testQuery=ABCDEFG', 'url should contain query');
     assert.equal(find('.item-name').text(), 'Item number one two three', 'redux state change should be rendered');
     assert.equal(find('.computed-query-param').text(), 'ABCDEFG', 'computed query params should be rendered');
+    assert.equal(find('.model').text(), '123', 'computed model should pull from statesToCompute');
   });
 });
 

--- a/tests/dummy/app/routes/item.js
+++ b/tests/dummy/app/routes/item.js
@@ -36,6 +36,7 @@ const stateToComputed = (state, params) => {
   Ember.Logger.debug(params);
 
   return {
+    model: params.item_id,
     item: getItemById(state, params.item_id),
     computedQueryParam: params.testQuery
   };


### PR DESCRIPTION
Reference - https://github.com/dustinfarris/ember-redux-route-connect/issues/6

Background
===
Moving the `this._super` higher in `setupController` allows the user to declare `model` as a key in `statesToCompute` which in turns allows Ember.Route's `this.modelFor` to properly reference parent models

Changes
===
* `super` now happens before the `defineProperty` section
* added a line to test that `.model` is populated with the correct entry
* added `model` to statesToCompute in `dummy/app/routes/item.js`