### PR TITLE
[bug] remove ember-redux from runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
-    "ember-redux": "^1.9.1"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Background
===
Since `ember-redux` 2.0.0, `ember-browserify` requirement has been dropped. However, because `package.json` has a `ember-redux: '1.9.1'` runtime dependency, npm will install `ember-redux: '1.9.1'` into the `node_modules` of `ember-redu-route-connect` addon when it is installed by an end-user. So if the end-user is running `ember-redux: `2.x.x'` and doesn't have `ember-browserify` installed, `ember build` will croak.

Changes
===
* remove `ember-redux` from the `dependencies` section in the `package.json`. NPM `dependencies` specify node runtime dependencies, which this addon (which exports only an es6 file `addon/index.js` doesn't actually need).

Suggestions
===
If we truly wanted to force an version of `ember-redux` on an user, we would need to write a blueprint.

```javascript
ember g blueprint ember-redux-route-connect
```

then use the `addAddonsToProject` method in the `afterInstall` hook:

```javascript
addAddonsToProject({
  packages: [
    { name: 'ember-redux', target: '2.1.0' }
  ]
});
```